### PR TITLE
🐛 Fix the problem of gitee upload error 403

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ module.exports = (ctx) => {
   const getHeaders = function () {
     return {
       "Content-Type": "application/json;charset=UTF-8",
-      "User-Agent": "PicGo",
     };
   };
 


### PR DESCRIPTION
gitee上传图片失败403
<img width="500" alt="image" src="https://github.com/zhanghuid/picgo-plugin-gitee/assets/59362976/ac6a2a06-19f7-44b9-a74d-f5360f5d483c">
经抓包排查，移除UA后上传成功

Gitee 官方API样例（无默认UA）：
<img width="500" alt="image" src="https://github.com/zhanghuid/picgo-plugin-gitee/assets/59362976/e1fb5a1b-93d7-4df8-87ff-d0392063f7e3">
